### PR TITLE
Add support for Mac/Unix line endings (\n) in PluginConfig.txt files

### DIFF
--- a/Codeable.Foundation.Web.Core/WebPreApplicationStartMethod.cs
+++ b/Codeable.Foundation.Web.Core/WebPreApplicationStartMethod.cs
@@ -341,7 +341,7 @@ namespace Codeable.Foundation.UI.Web.Core
             PluginConfig config = new PluginConfig();
             if (!string.IsNullOrEmpty(fileContents))
             {
-                string[] settings = fileContents.Split(new[] { "\r\n" }, StringSplitOptions.RemoveEmptyEntries);
+                string[] settings = fileContents.Split(new[] { "\n", "\r\n" }, StringSplitOptions.RemoveEmptyEntries);
                 foreach (string setting in settings)
                 {
                     int separatorIndex = setting.IndexOf(':');


### PR DESCRIPTION
Adds support for PluginConfig.txt files which happen to use `\n` as their line ending (as with Mac or Unix machines).