### PR TITLE
Add complete list of deps to nuspec

### DIFF
--- a/Codeable.Foundation.4.0.nuspec
+++ b/Codeable.Foundation.4.0.nuspec
@@ -9,6 +9,15 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Codeable's Application Foundation</description>
     <dependencies>
+      <dependency id="CommonServiceLocator" version="1.3" />
+      <dependency id="Microsoft.AspNet.Mvc" version="5.2.3" />
+      <dependency id="Microsoft.AspNet.Razor" version="3.2.3" />
+      <dependency id="Microsoft.AspNet.WebApi.Client" version="5.2.3" />
+      <dependency id="Microsoft.AspNet.WebApi.Core" version="5.2.3" />
+      <dependency id="Microsoft.AspNet.WebApi.WebHost" version="5.2.3" />
+      <dependency id="Microsoft.AspNet.WebPages" version="3.2.3" />
+      <dependency id="Microsoft.Web.Infrastructure" version="1.0.0.0" />
+      <dependency id="Newtonsoft.Json" version="6.0.8" />
       <dependency id="Unity" version="3.5.1404" />
     </dependencies>
   </metadata>


### PR DESCRIPTION
While investigating some bizarre build errors after updating dependencies in projects using Codeable.Foundation, I noticed that the nuspec was missing a number of required dependencies. This will help Visual Studio properly apply binding redirects and build the project when you update one of these deps.